### PR TITLE
Setting: Add colors, font-size, font-weight token to tailwind configuration

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -26,6 +26,10 @@
     "no-useless-catch": "off",
     "simple-import-sort/imports": "error",
     "simple-import-sort/exports": "error",
-    "import/prefer-default-export": "off"
+    "import/prefer-default-export": "off",
+    "react/function-component-definition": [
+      2,
+      { "namedComponents": "arrow-function" }
+    ]
   }
 }

--- a/components/index.ts
+++ b/components/index.ts
@@ -1,1 +1,1 @@
-export const a = {};
+export { default as Flex } from './layouts/Flex';

--- a/components/layouts/Flex.tsx
+++ b/components/layouts/Flex.tsx
@@ -1,0 +1,4 @@
+const Flex = () => {
+  return <div className="">Flex</div>;
+};
+export default Flex;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,9 +1,34 @@
-export const content = [
-  './app/**/*.{js,ts,jsx,tsx,mdx}',
-  './pages/**/*.{js,ts,jsx,tsx,mdx}',
-  './components/**/*.{js,ts,jsx,tsx,mdx}',
-];
-export const theme = {
-  extend: {},
-};
-export const plugins = [];
+import type { Config } from 'tailwindcss';
+
+export default {
+  content: [
+    './app/**/*.{js,ts,jsx,tsx,mdx}',
+    './components/**/*.{js,ts,jsx,tsx,mdx}',
+  ],
+  theme: {
+    extend: {
+      // arbitrary name
+      colors: {
+        bgBlack: '2D2D2D',
+        bgGrey700: '7A7A7A',
+        bgGrey500: 'BCBABA',
+        bgGrey100: 'F9F9F9',
+        textBlack: '343434',
+        pointYellow: 'FF9900',
+      },
+      fontSize: {
+        h1: '32px',
+        h2: '20px',
+        p1: '16px',
+        p2: '14px',
+        p3: '12px',
+        p4: '10px',
+      },
+      fontWeight: {
+        bold: '700',
+        regular: '400',
+      },
+    },
+  },
+  plugins: [],
+} satisfies Config;


### PR DESCRIPTION
# Description
Based on the design in Figma, set the basic tokens to tailwind configuration.
- Colors
- Font Size
- Font Weight

Named arbitrarily and need to be discussed about the naming, variant and everything with the designer.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)