### PR TITLE
Feature: Typography component

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,11 @@
-import { Avatar, Button, Grid, Input, PopularList } from '@/components';
+import {
+  Avatar,
+  Button,
+  Grid,
+  Input,
+  PopularList,
+  Typography,
+} from '@/components';
 
 const Home = () => {
   return (
@@ -9,6 +16,8 @@ const Home = () => {
         <Avatar size="md" src="" alt="avatar test" />
         <Input />
         <PopularList />
+        <Typography variant="h1">title</Typography>
+        <Typography variant="p1">description</Typography>
       </Grid>
     </main>
   );

--- a/components/UI/index.ts
+++ b/components/UI/index.ts
@@ -8,3 +8,4 @@ export { default as List } from './List';
 export { default as ListItem } from './ListItem';
 export { default as Select } from './Select';
 export { default as SelectItem } from './SelectItem';
+export { default as Typography } from './typography/Typography';

--- a/components/UI/typography/Typography.tsx
+++ b/components/UI/typography/Typography.tsx
@@ -1,0 +1,50 @@
+import { FC } from 'react';
+
+import { cn } from '@/utils';
+
+import { TagType, TypographyProps, VariantType } from './types';
+
+const Typography: FC<TypographyProps> = ({
+  children,
+  variant = 'p1',
+  className,
+  ...props
+}) => {
+  const variants: { [key in VariantType]: string } = {
+    h1: 'text-4xl font-bold',
+    h2: 'text-xl font-bold',
+    h3: 'text-base font-bold',
+    p1: 'text-base font-normal',
+    p2: 'text-sm font-normal',
+    p3: 'text-xs font-normal',
+    p4: 'text-2xs font-normal',
+  };
+
+  const getTagClass = (variant: VariantType) => {
+    switch (variant) {
+      case 'h1':
+        return 'h1';
+      case 'h2':
+        return 'h2';
+      case 'h3':
+        return 'h3';
+      case 'p1':
+      case 'p2':
+      case 'p3':
+      case 'p4':
+        return 'p';
+      default:
+        return 'span';
+    }
+  };
+
+  const Tag = getTagClass(variant) as TagType;
+
+  return (
+    <Tag className={cn(variants[variant], className)} {...props}>
+      {children}
+    </Tag>
+  );
+};
+
+export default Typography;

--- a/components/UI/typography/types.ts
+++ b/components/UI/typography/types.ts
@@ -1,0 +1,12 @@
+import { HTMLAttributes } from 'react';
+
+export type TagType = 'h1' | 'h2' | 'h3' | 'p' | 'span';
+export type VariantType = 'h1' | 'h2' | 'h3' | 'p1' | 'p2' | 'p3' | 'p4';
+
+export type HeadingType = HTMLAttributes<HTMLHeadingElement>;
+export type ParagraphType = HTMLAttributes<HTMLParagraphElement>;
+export type SpanType = HTMLAttributes<HTMLSpanElement>;
+
+export type TypographyProps = (HeadingType | ParagraphType | SpanType) & {
+  variant?: VariantType;
+};

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -18,6 +18,18 @@ module.exports = {
       fontBlack: '#343434',
       fontWhite: '#FFF',
     },
+    fontSize: {
+      '3xs': '8px',
+      '2xs': '10px',
+      xs: '12px',
+      sm: '14px',
+      base: '16px',
+      lg: '18px',
+      xl: '20px',
+      '2xl': '24px',
+      '3xl': '28px',
+      '4xl': '32px',
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
Add a Typography component `final!`
- Set up the `tag name` to be generated dynamically.
- Set up `variants` for h1, h2, h3 for titles / p1, p2, p3, p4 for the body (based on Figma)

*_There seems to be some confusion between the `Pad` and `Mobile` versions. so I'll add settings for screen sizes as soon as confirmed._